### PR TITLE
breaking: Upgrade alpine version (3.10->3.15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.3
+FROM alpine:3.15.0
 
 LABEL maintainer="team@codacy.com"
 


### PR DESCRIPTION
Upgrading the alpine version because the one we're currently using is too old, which is causing issues due to outdated ca-certificates.